### PR TITLE
fix markdown ordered list syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Morgan Nelson
 
 This is an activity for DevOps Live Meetup to allow experienced and non experience members to play with a repo for the purpose of talking about and using git.
 
-1.Fork the this repo
-2.Commit your name to this list
-3.Submit a pull request
-4.Verify that you pull request can be merged.
+1. Fork the this repo
+2. Commit your name to this list
+3. Submit a pull request
+4. Verify that you pull request can be merged.
 
 ## NAME LIST
 Cory Claflin


### PR DESCRIPTION
Currently the steps to play with the repo render all on a single line. This fixes the markdown syntax so that the steps render as an ordered list.
